### PR TITLE
Improved dependency management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.bundle/
 /.yardoc
 /Gemfile.lock
+/gemfiles/Gemfile-*.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
-sudo: false
-cache: bundler
+---
 language: ruby
+sudo: false
+
 rvm:
-  - 2.2.7
   - 2.3.4
   - 2.4.1
-before_install: gem install bundler -v 1.15.1
+
+gemfile:
+  - gemfiles/Gemfile-4.x
+  - gemfiles/Gemfile-5.x

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This Gem is a shameless copy of [cloudflare-rails](https://github.com/modosc/clo
 
 ## Installation
 
-__This gem now supports Rails 5,, for Rails 4, please use version ~> 0.1.0__
+__This gem supports Rails 4 and 5__
 
 Add this line to your application's Gemfile:
 

--- a/cloudfront-rails.gemspec
+++ b/cloudfront-rails.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
 
   spec.add_dependency "railties", "> 4.0"
-  spec.add_dependency "httparty"
 
   spec.required_ruby_version = ">= 2.0"
 end

--- a/cloudfront-rails.gemspec
+++ b/cloudfront-rails.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rspec-rails"
 
   spec.add_development_dependency "webmock"
 

--- a/cloudfront-rails.gemspec
+++ b/cloudfront-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "webmock"
 
-  spec.add_dependency "rails", "> 4.0"
+  spec.add_dependency "railties", "> 4.0"
   spec.add_dependency "httparty"
 
   spec.required_ruby_version = ">= 2.0"

--- a/cloudfront-rails.gemspec
+++ b/cloudfront-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "webmock"
 
-  spec.add_dependency "rails", "~> 5.0"
+  spec.add_dependency "rails", "> 4.0"
   spec.add_dependency "httparty"
 
   spec.required_ruby_version = ">= 2.0"

--- a/gemfiles/Gemfile-4.x
+++ b/gemfiles/Gemfile-4.x
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 4.0'

--- a/gemfiles/Gemfile-4.x
+++ b/gemfiles/Gemfile-4.x
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', '~> 4.0'
+gem 'railties', '~> 4.0'

--- a/gemfiles/Gemfile-5.x
+++ b/gemfiles/Gemfile-5.x
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'rails', '~> 5.0'
+gem 'railties', '~> 5.0'

--- a/gemfiles/Gemfile-5.x
+++ b/gemfiles/Gemfile-5.x
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'rails', '~> 5.0'

--- a/lib/cloudfront/rails.rb
+++ b/lib/cloudfront/rails.rb
@@ -1,5 +1,4 @@
 require "rails"
-require "httparty"
 
 require "cloudfront/rails/version"
 
@@ -10,4 +9,5 @@ module Cloudfront
 end
 
 require "cloudfront/rails/importer"
+require "cloudfront/rails/importer/response_error"
 require "cloudfront/rails/railtie"

--- a/lib/cloudfront/rails.rb
+++ b/lib/cloudfront/rails.rb
@@ -1,4 +1,5 @@
 require "rails"
+require "net/http"
 
 require "cloudfront/rails/version"
 

--- a/lib/cloudfront/rails.rb
+++ b/lib/cloudfront/rails.rb
@@ -1,3 +1,6 @@
+require "rails"
+require "httparty"
+
 require "cloudfront/rails/version"
 
 module Cloudfront
@@ -6,4 +9,5 @@ module Cloudfront
   end
 end
 
+require "cloudfront/rails/importer"
 require "cloudfront/rails/railtie"

--- a/lib/cloudfront/rails/importer.rb
+++ b/lib/cloudfront/rails/importer.rb
@@ -1,0 +1,42 @@
+module Cloudfront
+  module Rails
+    class Importer
+      include HTTParty
+
+      base_uri "https://ip-ranges.amazonaws.com"
+      follow_redirects true
+      default_options.update(verify: true)
+
+      class ResponseError < HTTParty::ResponseError; end
+
+      class << self
+        def fetch
+          resp = get "/ip-ranges.json", timeout: ::Rails.application.config.cloudfront.timeout
+
+          if resp.success?
+            json = ActiveSupport::JSON.decode resp
+
+            trusted_ipv4_proxies = json["prefixes"].map do |details|
+                                     IPAddr.new(details["ip_prefix"])
+                                   end
+
+            trusted_ipv6_proxies = json["ipv6_prefixes"].map do |details|
+                                     IPAddr.new(details["ipv6_prefix"])
+                                   end
+
+            trusted_ipv4_proxies + trusted_ipv6_proxies
+          else
+            raise ResponseError.new(resp.response)
+          end
+        end
+
+        def fetch_with_cache
+          ::Rails.cache.fetch("cloudfront-rails-ips",
+                              expires_in: ::Rails.application.config.cloudfront.expires_in) do
+            self.fetch
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudfront/rails/importer/response_error.rb
+++ b/lib/cloudfront/rails/importer/response_error.rb
@@ -1,0 +1,13 @@
+module Cloudfront
+  module Rails
+    class Importer
+      class ResponseError < StandardError
+        attr_reader :response
+
+        def initialize(response)
+          @response = response
+        end
+      end
+    end
+  end
+end

--- a/lib/cloudfront/rails/railtie.rb
+++ b/lib/cloudfront/rails/railtie.rb
@@ -10,7 +10,11 @@ module Cloudfront
         end
       end
 
-      Rack::Request::Helpers.prepend CheckTrustedProxies
+      if ::Rails.version.start_with? '4.'
+        Rack::Request.prepend CheckTrustedProxies
+      else
+        Rack::Request::Helpers.prepend CheckTrustedProxies
+      end
 
       module RemoteIpProxies
         def proxies

--- a/lib/cloudfront/rails/railtie.rb
+++ b/lib/cloudfront/rails/railtie.rb
@@ -1,6 +1,3 @@
-require "rails"
-require "httparty"
-
 module Cloudfront
   module Rails
     class Railtie < ::Rails::Railtie
@@ -24,45 +21,6 @@ module Cloudfront
       end
 
       ActionDispatch::RemoteIp.prepend RemoteIpProxies
-
-      class Importer
-        include HTTParty
-
-        base_uri "https://ip-ranges.amazonaws.com"
-        follow_redirects true
-        default_options.update(verify: true)
-
-        class ResponseError < HTTParty::ResponseError; end
-
-        class << self
-          def fetch
-            resp = get "/ip-ranges.json", timeout: ::Rails.application.config.cloudfront.timeout
-
-            if resp.success?
-              json = ActiveSupport::JSON.decode resp
-
-              trusted_ipv4_proxies = json["prefixes"].map do |details|
-                                       IPAddr.new(details["ip_prefix"])
-                                     end
-
-              trusted_ipv6_proxies = json["ipv6_prefixes"].map do |details|
-                                       IPAddr.new(details["ipv6_prefix"])
-                                     end
-
-              trusted_ipv4_proxies + trusted_ipv6_proxies
-            else
-              raise ResponseError.new(resp.response)
-            end
-          end
-
-          def fetch_with_cache
-            ::Rails.cache.fetch("cloudfront-rails-ips",
-                                expires_in: ::Rails.application.config.cloudfront.expires_in) do
-              self.fetch
-            end
-          end
-        end
-      end
 
       CLOUDFRONT_DEFAULTS = {
         expires_in: 12.hours,

--- a/lib/cloudfront/rails/railtie.rb
+++ b/lib/cloudfront/rails/railtie.rb
@@ -1,3 +1,4 @@
+require "rails"
 require "httparty"
 
 module Cloudfront

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,5 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 ENV["RAILS_ENV"] ||= 'test'
 
-require "rubygems"
-
-require "action_controller/railtie"
-require 'action_view/railtie'
-require "rails/test_unit/railtie"
-
 require "cloudfront/rails"
-
 require "webmock/rspec"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,9 +10,4 @@ require "rails/test_unit/railtie"
 
 require "cloudfront/rails"
 
-require "rspec/rails"
 require "webmock/rspec"
-
-RSpec.configure do |config|
-  config.infer_base_class_for_anonymous_controllers = false
-end


### PR DESCRIPTION
### Summary

These changes reduce the amount of dependencies. I would like to use the gem in a Rails app, which doesn't use active record. But by adding `cloudfront-rails` the active record would be added to my gem list. Additionally the gem uses only one feature of httparty, which is following redirects. But redirects are actually not expected on the fetched end point. So we can just as well treat this as an error.

The changes also add back support for Rails 4, since I am managing apps with both versions at the moment.

### Changes

* Adding switch to support both Rails 4 and Rails 5 at the same time - updating travis configuration so that the Gem is tested with both version. Removing deprecated Ruby 2.2 test to reduce the load on travis.
* Removing `rspec-rails` dependency, since it wasn't used anyway
* Replacing `rails` dependency with `railties`. This way we get rid of `activerecord`, `actionmailer` and what not. Since we only just define a `Railtie` and depend on `ActionController`, depending on `railties` is good enough.
* Replace `httparty` code with plain `net/http`. Moving around code in the process for better gem layout.