### PR TITLE
Fix the startup exception

### DIFF
--- a/lib/cloudfront/rails/railtie.rb
+++ b/lib/cloudfront/rails/railtie.rb
@@ -34,7 +34,7 @@ module Cloudfront
             resp = get "/ip-ranges.json", timeout: ::Rails.application.config.cloudfront.timeout
 
             if resp.success?
-              json = ActiveSupport::JSON.decode resp
+              json = ActiveSupport::JSON.decode resp.body
 
               trusted_ipv4_proxies = json["prefixes"].map do |details|
                                        IPAddr.new(details["ip_prefix"])


### PR DESCRIPTION
This is good gem!

BTW, I got following message in startup Rails (use Ruby 2.3.1, Rails 5.1.2):

```
Cloudfront::Rails: Got exception: no implicit conversion of HTTParty::Response into String
```