### PR TITLE
allow to work with httparty 0.13 and above

### DIFF
--- a/cloudfront-rails.gemspec
+++ b/cloudfront-rails.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
 
   spec.add_dependency "rails", "~> 4.0"
-  spec.add_dependency "httparty"
+  spec.add_dependency "httparty", ">= 0.13.7"
 
   spec.required_ruby_version = ">= 2.0"
 end

--- a/lib/cloudfront/rails/railtie.rb
+++ b/lib/cloudfront/rails/railtie.rb
@@ -34,7 +34,7 @@ module Cloudfront
             resp = get "/ip-ranges.json", timeout: ::Rails.application.config.cloudfront.timeout
 
             if resp.success?
-              json = ActiveSupport::JSON.decode resp
+              json = ActiveSupport::JSON.decode resp.body
 
               trusted_ipv4_proxies = json["prefixes"].map do |details|
                                        IPAddr.new(details["ip_prefix"])

--- a/lib/cloudfront/rails/version.rb
+++ b/lib/cloudfront/rails/version.rb
@@ -1,5 +1,5 @@
 module Cloudfront
   module Rails
-    VERSION = "0.1.0"
+    VERSION = "0.1.1"
   end
 end


### PR DESCRIPTION
HttParty should be able to work with version 0.13.7 and above. Also, it looks like a separate branch for version 0.1.0 is necessary so that this can be merged into it.

Should close out this issue https://github.com/dinks/cloudfront-rails/issues/6